### PR TITLE
Minor bump to cirq versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ python_requires = >=3.9,!=3.9.7
 install_requires =
     #This is to fix unbounded dependency in cirq 0.13
     protobuf<4
-    cirq-core~=1.2.0
-    cirq-google~=1.2.0
+    cirq-core~=1.3.0
+    cirq-google~=1.3.0
     orquestra-quantum
     openfermion~=1.6.0
 


### PR DESCRIPTION
## Cirq updates

- Context: we encountered a package installation conflict between two packages BenchQ and pyLIQTR involving cirq. BenchQ required orquestra-cirq 0.12.0 which depends on cirq-core~=1.2.0, while pyliqtr 1.2.0 depends on cirq-core==1.3.0.dev20231018023458.
- Solution: in orquestra-cirq bumped the cirq-core and cirq-google versions to ~=1.3.0

## Please verify that you have completed the following steps

- [x] I have self-reviewed my code.
- [x] I have included test cases validating introduced feature/fix.
- [ ] I have updated documentation.
